### PR TITLE
:alembic: :sparkles: ci: Add html-tidy job for publishing clean HTML

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,14 +15,33 @@ workflows:
           htmlproofer-url-ignore: "'/drone-4sdgtoolkit/'"
           htmlproofer-timeframe: "'6w'"
           version: "latest"
-      - deploy:
+      - html-tidy:
           filters:
             branches:
               only: main
           requires:
             - hugo/build
+      - deploy:
+          filters:
+            branches:
+              only: main
+          requires:
+            - html-tidy
+            - hugo/build
 
 jobs:
+  html-tidy:
+    docker:
+      - image: cimg/ruby:3.0
+    steps:
+      - run: gem install htmlbeautifier
+      - attach_workspace:
+          at: .
+      - run: htmlbeautifier --tab $(find public/ -name '*.html' -print)
+      - persist_to_workspace:
+          root: .
+          paths:
+            - public
   deploy:
     docker:
       - image: cibuilds/base:latest


### PR DESCRIPTION
This commit adds a new CircleCI job that cleans and beautifies the HTML
before it goes to the deployment job. This makes HTML on the production
site in GitHub Pages easier for humans to inspect and read.