### PR TITLE
:wrench: config: Add Toolkits menu and link to other UNICEF toolkits

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,30 @@ name = "About"
 url = "about"
 
 [[menu.main]]
+weight = 15
+name = "toolkits"
+url = "toolkits"
+hasChildren = true
+
+    [[menu.main]]
+    parent = "toolkits"
+    name = "Data Science & A.I."
+    url = "https://unicef.github.io/ooi-toolkit-ds/"
+    weight = 10
+
+    [[menu.main]]
+    parent = "toolkits"
+    name = "Open Source"
+    url = "https://unicef.github.io/inventory/"
+    weight = 20
+
+    [[menu.main]]
+    parent = "toolkits"
+    name = "Software Development"
+    url = "https://unicef.github.io/ooi-toolkit-software/"
+    weight = 30
+
+[[menu.main]]
 weight = 20
 name = "pages"
 url = "pages"


### PR DESCRIPTION
This commit adds a new drop-down menu to the UNICEF Drones for
Sustainable Development Goals Toolkit. The _Toolkits_ drop-down includes
links to @dalvarez83's Data Science & A.I. Toolkit, @jwflory's Open
Source Inventory, and @iperdomo's Software Development Toolkit.

![Screenshot of the upper-right portion of the screen. The toolkits menu is shown and links out to the other toolkits that already exist.](https://user-images.githubusercontent.com/4721034/167940985-55656b31-a383-430f-b704-9ebfea3a5d0b.png "Screenshot of the upper-right portion of the screen. The toolkits menu is shown and links out to the other toolkits that already exist.")
